### PR TITLE
Test Fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,20 @@ jobs:
       - name: Execute PHPStan
         run: vendor/bin/phpstan analyse --no-progress
 
+  code-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          extensions: mbstring, pdo, pdo_sqlite
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction
+
       - name: Execute Pint
         run: vendor/bin/pint --test
 


### PR DESCRIPTION
- Remove Pint from the test matrix - No more running it multiple times with different PHP/Laravel versions
- add a separate code-style job - Runs Pint once with PHP 8.2 (same as your local environment)
- Consistent environment - No more version conflicts causing formatting differences