### PR TITLE
Enhancement/Test Creation Optional

### DIFF
--- a/src/Console/Commands/SpecificationMakeCommand.php
+++ b/src/Console/Commands/SpecificationMakeCommand.php
@@ -210,7 +210,6 @@ class SpecificationMakeCommand extends GeneratorCommand
         return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
     }
 
-
     /**
      * Get the console command arguments.
      */

--- a/src/Console/Commands/SpecificationMakeCommand.php
+++ b/src/Console/Commands/SpecificationMakeCommand.php
@@ -51,10 +51,8 @@ class SpecificationMakeCommand extends GeneratorCommand
             return false;
         }
 
-        // Generate test if requested
-        if ($this->option('test') || $this->option('pest')) {
-            $this->handleTestCreation();
-        }
+        // Use the trait's method for test creation (only creates if --test or --pest options are used)
+        $this->handleTestCreation($this->getPath($this->getNameInput()));
 
         return $result;
     }
@@ -212,22 +210,6 @@ class SpecificationMakeCommand extends GeneratorCommand
         return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
     }
 
-    /**
-     * Handle the test creation.
-     */
-    protected function handleTestCreation(): void
-    {
-        $testType = $this->option('pest') ? 'pest' : 'test';
-
-        $this->call('make:test', [
-            'name' => Str::of($this->argument('name'))
-                ->replace('\\', '/')
-                ->append('Test')
-                ->value(),
-            '--unit' => true,
-            '--pest' => $this->option('pest'),
-        ]);
-    }
 
     /**
      * Get the console command arguments.
@@ -250,7 +232,7 @@ class SpecificationMakeCommand extends GeneratorCommand
             ['composite', 'c', InputOption::VALUE_NONE, 'Create a composite specification with example composition'],
             ['cacheable', null, InputOption::VALUE_NONE, 'Include the CacheableSpecification trait'],
             ['builder', 'b', InputOption::VALUE_NONE, 'Generate specification using the builder pattern'],
-            // test option is already provided by CreatesMatchingTest trait
+            ['test', null, InputOption::VALUE_NONE, 'Generate an accompanying PHPUnit test'],
             ['pest', null, InputOption::VALUE_NONE, 'Generate an accompanying Pest test'],
             ['type', null, InputOption::VALUE_OPTIONAL, 'The type of specification (query, collection, both)', 'both'],
             ['inline', null, InputOption::VALUE_NONE, 'Create specification without domain folder structure'],

--- a/tests/Console/SpecificationMakeCommandTest.php
+++ b/tests/Console/SpecificationMakeCommandTest.php
@@ -327,12 +327,12 @@ class SpecificationMakeCommandTest extends TestCase
 
         // The trait's handleTestCreation method creates tests in tests/Feature/ by default
         $testPath = base_path('tests/Feature/Specifications/WithTestSpecificationTest.php');
-        
+
         // If that doesn't exist, check the simplified path
-        if (!File::exists($testPath)) {
+        if (! File::exists($testPath)) {
             $testPath = base_path('tests/Feature/WithTestSpecificationTest.php');
         }
-        
+
         $this->assertFileExists($testPath);
 
         // Clean up the test file and directory


### PR DESCRIPTION
When using the make:specification command, create specification test only if user provides the appropriate option flag to do so